### PR TITLE
⚠️[EMG]-#31-jwt 헤더 인식 불가 해결

### DIFF
--- a/src/main/java/com/likelion/spoonclass/config/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/likelion/spoonclass/config/auth/jwt/JwtProvider.java
@@ -110,7 +110,7 @@ public class JwtProvider {
      * @return
      */
     public String resolve(HttpServletRequest request){
-        return request.getHeader("X-AUTH_TOKEN");
+        return request.getHeader("X-AUTH-TOKEN");
     }
 
     public String setInvalidJwtMessage(String jwtToken){


### PR DESCRIPTION
# 커밋 내용 (한 줄 72자 내)
jwtProvider 에서 X-AUTH-TOKEN 형태로 바꿔준다.

## ISSUES
<!-- 관련된 이슈번호 작성 -->
  #31 

## PR 목적
jwt 인증 오류 해결 및 배포 

## 참고 사항
